### PR TITLE
Remove duplicate call after master merge

### DIFF
--- a/iphone/Classes/TiGaTrackerProxy.m
+++ b/iphone/Classes/TiGaTrackerProxy.m
@@ -137,10 +137,6 @@
 
     [self handleCustomFields:builder jshash:args];
     [_tracker send:[builder build]];
-    [_tracker send:[[GAIDictionaryBuilder createEventWithCategory:category
-                                                            action:action
-                                                            label:label
-                                                            value:value] build]];
 }
 
 -(void)addTiming:(id)args


### PR DESCRIPTION
Somewhere when merging into master, duplicate code was created. Events are now send twice! Preferring the send that supports additional custom fields.