### PR TITLE
fix module ndk error when building on android

### DIFF
--- a/android/src/ti/ga/TigaModule.java
+++ b/android/src/ti/ga/TigaModule.java
@@ -76,7 +76,7 @@ public class TigaModule extends KrollModule
 
 	// Properties
 	@Kroll.getProperty
-	public long getDispatchInterval()
+	public int getDispatchInterval()
 	{
 		return _dispatchInterval;
 	}


### PR DESCRIPTION
fix getDispatchInterval() signature on android

this will prevent the following error:

`[INFO]  Running the Android NDK ndk-build
[ERROR] Failed to run ndk-build
[ERROR]
[ERROR] /Users/giorgio/Ti.GA/android/build/generated/obj/local/arm64-v8a/objs/ti.ga/ti.ga.TigaModule.o: In function `titanium::TypeConverter::javaLongToJsNumber(v8::Isolate*, _JNIEnv*, long)':
[ERROR] /Users/giorgio/Library/Application Support/Titanium/mobilesdk/osx/7.0.2.GA/android/native/include/TypeConverter.h:54: undefined reference to `titanium::TypeConverter::javaLongToJsNumber(v8::Isolate*, long)'
[ERROR] clang++: error: linker command failed with exit code 1 (use -v to see invocation)
[ERROR] make: *** [/Users/giorgio/Ti.GA/android/build/generated/obj/local/arm64-v8a/libti.ga.so] Error 1`

mentioned also in https://github.com/benbahrenburg/Ti.GA/pull/18#issuecomment-351445159